### PR TITLE
Change package name and repo to point to Hudl version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "react-avatar-editor",
+    "name": "hudl-react-avatar-editor",
     "version": "3.2.0",
     "description": "Facebook like avatar / profile picture component. Resize and crop your uploaded image using a intuitive user interface.",
     "main": "dist/index.js",
@@ -21,7 +21,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git://github.com/mosch/react-avatar-editor.git"
+        "url": "git://github.com/hudl/react-avatar-editor.git"
     },
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
Just doing this to avoid name confusion with the public package and in case TeamCity or someone uses the repository link.
