### PR TITLE
Hudl CI and Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,11 @@
         "reactify": "0.17.1",
         "uglifyjs": "^2.4.10",
         "watchify": "^3.2.2"
+    },
+    "hudl-ci": {
+      "buildCommand": "npm run build",
+    },
+    "publishConfig": {
+      "registry": "http://npm.thorhudl.com"
     }
 }


### PR DESCRIPTION
Add buildCommand and registry for TeamCity per these instructions:

https://sync.hudl.com/pages/viewpage.action?spaceKey=WEBSQ&title=Build+and+publish+an+npm+package+with+TeamCity
